### PR TITLE
feat(release): update downstream

### DIFF
--- a/.github/workflows/release-increased-version.yml
+++ b/.github/workflows/release-increased-version.yml
@@ -58,3 +58,20 @@ jobs:
     with:
       ref: "refs/tags/v${{ needs.tag-release.outputs.current-version }}"
     secrets: inherit
+
+  update-downstream:
+    name: Update downstream distribution
+    needs: ['call-build-push']
+    uses: actions/github-script@v7
+    if: needs.tag-release.outputs.previous-version != needs.tag-release.outputs.current-version
+    with:
+      script: |
+        github.rest.actions.createWorkflowDispatch({
+          owner: context.repo.owner,
+          repo: 'wiki-oci-distribution',
+          workflow_id: 'increase-base-version.yml',
+          ref: 'main',
+          inputs:
+            previous-version: "${{ needs.tag-release.outputs.previous-version }}",
+            next-version: "${{ needs.tag-release.outputs.current-version }}"
+        })


### PR DESCRIPTION
This adds an update-downstream job which dispatches the increase-base-version workflow in the wiki-oci-distribution repository to sync the base version.

This is largely based on:

* https://github.com/actions/github-script/issues/250
* https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/