### PR TITLE
fix(release): update downstream

### DIFF
--- a/.github/workflows/release-increased-version.yml
+++ b/.github/workflows/release-increased-version.yml
@@ -60,18 +60,26 @@ jobs:
     secrets: inherit
 
   update-downstream:
-    name: Update downstream distribution
+    runs-on: ubuntu-latest
     needs: ['call-build-push']
-    uses: actions/github-script@v7
-    if: needs.tag-release.outputs.previous-version != needs.tag-release.outputs.current-version
-    with:
-      script: |
-        github.rest.actions.createWorkflowDispatch({
-          owner: context.repo.owner,
-          repo: 'wiki-oci-distribution',
-          workflow_id: 'increase-base-version.yml',
-          ref: 'main',
-          inputs:
-            previous-version: "${{ needs.tag-release.outputs.previous-version }}",
-            next-version: "${{ needs.tag-release.outputs.current-version }}"
-        })
+    steps:
+      - name: Update downstream distribution
+        uses: actions/github-script@v7
+        if: needs.tag-release.outputs.previous-version != needs.tag-release.outputs.current-version
+        with:
+          script: |
+            try {
+              const result = await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: 'wiki-oci-distribution',
+                workflow_id: 'increase-base-version.yml',
+                ref: 'main',
+                inputs:
+                  previous-version: "${{ needs.tag-release.outputs.previous-version }}",
+                  next-version: "${{ needs.tag-release.outputs.current-version }}"
+              })
+              console.log(result);
+            } catch(error) {
+              console.error(error);
+              core.setFailed(error);
+            }


### PR DESCRIPTION
GitHub Actions can only be used in steps, not in jobs.

Also wraps error handling from the other example in the previous commit.